### PR TITLE
Add upload script

### DIFF
--- a/tax-thiefs-web/upload.sh
+++ b/tax-thiefs-web/upload.sh
@@ -1,0 +1,2 @@
+npm run build
+aws s3 cp build/ s3://tax-thiefs.com --recursive --acl public-read


### PR DESCRIPTION
AWS에 업로드 하기 위해서 프로젝트 파일을 빌드하고 빌드한 파일을 AWS S3버킷안에 업로드했습니다.
권한을 public으로 변경하여 누구나 접근가능하게 만들었습니다.
그리고 이 과정을 간단하게 하기 위해서 AWS cli를 사용했습니다.
명령어를 `upload.sh`파일에 입력해서 쉽게 업로드할 수 있게 만들었습니다.

업로드한 것은 https://d3almo5yefgr0j.cloudfront.net/ 여기서 확인하실 수 있습니다.

See also
  - https://docs.aws.amazon.com/cli/latest/reference/s3/#single-local-file-and-s3-object-operations